### PR TITLE
polsat: offset EPG wedlug strefy uzytkownika

### DIFF
--- a/srcs/plugin.video.pgobox/main.py
+++ b/srcs/plugin.video.pgobox/main.py
@@ -649,13 +649,16 @@ class IPLA(object):
         addon.setSetting('sesskey', self.SESSKEY)
         return self.SESSTOKEN+'|'+self.SESSEXPIR+'|{0}|{1}'
         
+    def local_time(ff):
+        from datetime import datetime, timedelta, timezone
+        return ff + datetime.now(timezone.utc).astimezone().utcoffset()
         
     def newtime(self,ff):
         from datetime import datetime
         ff=re.sub(':\d+Z','',ff)
         dd=re.findall('T(\d+)',ff)[0]
         dzien=re.findall('(\d+)T',ff)[0]
-        dd='{:>02d}'.format(int(dd)+2)
+        dd='{:>02d}'.format(int(dd))
         if dd=='24':
             dd='00'
             dzien='{:>02d}'.format(int(dzien)+1)
@@ -671,7 +674,7 @@ class IPLA(object):
             format_date=datetime(*(time.strptime(ff, '%Y-%m-%dT%H:%M')[0:6]))
         dd= int('{:0}'.format(int(time.mktime(format_date.timetuple()))))
 
-        return dd,format_date   
+        return dd,local_time(format_date)
     
     def getSzukaj(self,query):
         self.getSesja()

--- a/srcs/plugin.video.polsatgo/main.py
+++ b/srcs/plugin.video.polsatgo/main.py
@@ -714,8 +714,8 @@ def tvmain():
     return urls
 
 def local_time(ff):
-    from datetime import datetime, timedelta
-    return ff - timedelta(hours=1)
+    from datetime import datetime, timedelta, timezone
+    return ff + datetime.now(timezone.utc).astimezone().utcoffset()
 
 def newtime(ff):
     from datetime import datetime
@@ -724,7 +724,7 @@ def newtime(ff):
     ff=re.sub(':\d+Z','',ff)
     dd=re.findall('T(\d+)',ff)[0]
     dzien=re.findall('(\d+)T',ff)[0]
-    dd='{:>02d}'.format(int(dd)+2)
+    dd='{:>02d}'.format(int(dd))
     if dd=='24':
         dd='00'
         dzien='{:>02d}'.format(int(dzien)+1)


### PR DESCRIPTION
APi zwraca godzinę w UTC, najprościej sformatować ją dodając lokalny offset. Kod sprawdzałem na CP Go, strefy GMT i GMT+1 działają prawidłowo.